### PR TITLE
Feat: 테스트 결과 리스트 변환 메서드 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,6 +226,7 @@
 
                     <py-script>
                         #from testCaseAndResult import test
+                        import pyodide
                         from testcase import testcase_and_result
 
                         PAGE_NAME = js.document.querySelector('.active').id[1:]
@@ -267,10 +268,11 @@
                                 fail = "&lt;span class='result-fail'&gt; 실패 &lt;&#47;span&gt;"
                                 result_save_localstorage = []
 
-                                if ',' in str(result[0]):
-                                    for i in range(3):
-                                        result[i] = list(result[i])
-                                
+                                for i in range(3):
+                                    if isinstance(result[i], pyodide.JsProxy):
+                                        # JS 객체, 배열, 함수, 프로미스인 경우
+                                        result[i]=list(result[i])
+
                                 for i in range(3):
                                     resultString += f"&lt;p class='que-result-{i} checkPass'&gt;test{i+1} : {passing if result[i] == answer[i] else fail}&lt;span class='result-compare'&gt;({result[i]} == {answer[i]})&lt;&#47;span&gt;&lt;&#47;p&gt;"
                                     result_save_localstorage.append(result[i] == answer[i])


### PR DESCRIPTION
### 요악
- pyodide.JsProxy 를 사용하여 자바스크립트 배열임을 판별
- 반환값이 string과 배열이 함께 나오는 문항(Ex.10)이 있어 각 결괏값을 순회하며 판별하여 변환
<img width="475" alt="image" src="https://user-images.githubusercontent.com/96777064/224866112-dee24eef-bd64-49ae-b843-1fbd783dda5a.png">

### 추가 전달 사항
- pyodide.JsProxy를 통해 자바스크립트의 객체, 배열, 함수, 프로미스를 판별합니다.
- 현재 테스트 케이스에 배열만이 포함되어 있으므로 Pyodide.JsProxy로 판별된 결괏값은 배열로 취급합니다.